### PR TITLE
feat(shared): browser-safe shared entry to fix frontend build

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -60,6 +60,21 @@ Stage Roadmap (Milestones):
 - `backend/` – Asynchronous world simulation (queue triggers), heavier domain logic
 - `shared/` (future) – Reusable graph + validation helpers
 
+### Shared Package Entry Points (Browser vs Backend)
+
+The `@atlas/shared` workspace now exposes **two entry points** to keep the frontend bundle free of Node‑only dependencies:
+
+- `index.ts` (default / backend): full export surface, including telemetry initialization that references Node built‑ins (`node:crypto`) and the Azure Application Insights SDK.
+- `index.browser.ts` (browser-mapped via the `"browser"` field in `shared/package.json`): minimal, currently exports only canonical telemetry event name constants. It deliberately omits telemetry initialization and any code touching Node APIs.
+
+Bundlers (Vite/Rollup) automatically substitute the browser build when targeting the frontend, preventing accidental inclusion of heavy or incompatible modules. When adding new shared utilities for the frontend, export them from `index.browser.ts` **only if** they are:
+
+1. Pure TypeScript/JS (no dynamic `require`, no Node built‑ins like `fs`, `net`, `crypto` beyond standard web APIs).
+2. Side‑effect free (no environment inspection or global initialization).
+3. Stable (domain constants, pure functions, type definitions).
+
+If a utility requires conditional behavior (different in backend vs browser), prefer a thin adapter in the frontend rather than branching logic inside shared code, to keep the browser surface auditable and tree‑shakable.
+
 ## Data & World Graph Principles
 
 - Stable GUIDs for all nodes (players, rooms, NPCs)
@@ -106,4 +121,4 @@ Other documents (like `mvp-azure-architecture.md`) dive into concrete resource d
 
 ---
 
-_Last updated: 2025-09-25 (added Agentic AI & MCP preview section)_
+_Last updated: 2025-10-02 (added Shared Package entry point separation section)_

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,6 +11,9 @@
             "types": "./dist/index.d.ts"
         }
     },
+    "browser": {
+        "./dist/index.js": "./dist/index.browser.js"
+    },
     "files": [
         "dist"
     ],

--- a/shared/src/index.browser.ts
+++ b/shared/src/index.browser.ts
@@ -1,0 +1,4 @@
+// Browser-focused entry point for @atlas/shared
+// Exposes only symbols that are safe for frontend bundles (excludes Node/AppInsights backend telemetry initialization).
+// If additional shared types/utilities are needed in the frontend, add re-exports here cautiously, ensuring they have no Node built-in dependencies.
+export * from './telemetryEvents.js'


### PR DESCRIPTION
## Summary
Adds a browser-focused entry point to `@atlas/shared` and documents the separation. This resolves the previous `vite build` failure caused by bundling backend-only telemetry initialization (Node `randomUUID` / `node:crypto` + `applicationinsights`).

## Changes
- `shared/package.json`: Added `browser` field mapping `./dist/index.js` -> `./dist/index.browser.js`.
- `shared/src/index.browser.ts`: New file exporting only `telemetryEvents` (canonical event names) – no Node built-ins or side effects.
- `docs/architecture/overview.md`: Added section "Shared Package Entry Points (Browser vs Backend)" with criteria for adding browser exports; updated last-updated stamp.

## Rationale
The frontend only needs event name constants but importing the package root brought in `telemetry.ts`, which initializes Application Insights and references Node APIs. Vite externalized many core modules and ultimately failed on `randomUUID`.

Providing an explicit browser entry keeps the frontend bundle lean and avoids accidental inclusion of server-only dependencies.

## Verification
- `npm run build -w frontend` now succeeds (bundle ~191 KB gzip ~61 KB JS; no crypto/randomUUID errors).
- Full test suite passes (`npm test`): 95 backend/shared tests + integration tests all green.

## Criteria for Browser Exports
1. Pure (no Node built-ins / dynamic require)
2. Side-effect free
3. Stable domain constants or pure utilities

## Follow-ups (Optional)
- Add selective additional pure helpers to `index.browser.ts` as needed.
- Consider a smoke test ensuring importing `@atlas/shared` from frontend never pulls backend telemetry.

---
Let me know if you'd like further refinement or additional docs.