### PR TITLE
refactor(shared): remove deprecated sync persistence loader & tighten secret access rule

### DIFF
--- a/backend/src/mcp/worldQuery.ts
+++ b/backend/src/mcp/worldQuery.ts
@@ -9,16 +9,18 @@ import { app, HttpRequest, HttpResponseInit } from '@azure/functions'
  *  - op=getStarter (shorthand) returns starter location
  * Future: listRecentEvents, getPlayerState
  */
-const locationRepo = getLocationRepository()
+const locationRepoPromise = getLocationRepository()
 
 export async function worldQueryHandler(req: HttpRequest): Promise<HttpResponseInit> {
     const op = req.query.get('op') || 'getStarter'
     if (op === 'getStarter') {
+        const locationRepo = await locationRepoPromise
         const location = await locationRepo.get(STARTER_LOCATION_ID)
         return json(200, { location })
     }
     if (op === 'getLocation') {
         const id = req.query.get('id') || STARTER_LOCATION_ID
+        const locationRepo = await locationRepoPromise
         const location = await locationRepo.get(id)
         if (!location) return json(404, { error: 'Location not found', id })
         return json(200, { location })

--- a/backend/test/playerRepository.test.ts
+++ b/backend/test/playerRepository.test.ts
@@ -5,7 +5,7 @@ import { test } from 'node:test'
 
 test('player repository assigns starting location', async () => {
     __resetPlayerRepositoryForTests()
-    const repo = getPlayerRepository()
+    const repo = await getPlayerRepository()
     const { record, created } = await repo.getOrCreate()
     assert.ok(created, 'expected new record')
     const currentLocationId = (record as PlayerRecord).currentLocationId

--- a/eslint-rules/no-direct-secret-access.mjs
+++ b/eslint-rules/no-direct-secret-access.mjs
@@ -21,7 +21,6 @@ export default {
         const allowed =
             /shared\/src\/secrets\/secretsHelper\.ts$/.test(filename) ||
             /shared\/test\/secretsHelper\.test\.ts$/.test(filename) ||
-            /shared\/src\/persistenceConfig\.ts$/.test(filename) ||
             /\.env\.development\.example$/.test(filename)
 
         // Secret environment variable names that should go through the helper

--- a/frontend/api/src/functions/location.ts
+++ b/frontend/api/src/functions/location.ts
@@ -17,12 +17,13 @@ import {
 } from '@atlas/shared'
 import { app, HttpRequest, HttpResponseInit } from '@azure/functions'
 
-const locationRepo = getLocationRepository()
+const locationRepoPromise = getLocationRepository()
 const headingStore = getPlayerHeadingStore()
 
 export async function getLocationHandler(req: HttpRequest): Promise<HttpResponseInit> {
     const started = Date.now()
     const id = req.query.get('id') || STARTER_LOCATION_ID
+    const locationRepo = await locationRepoPromise
     const location = await locationRepo.get(id)
     const playerGuid = extractPlayerGuid(req.headers)
     const correlationId = extractCorrelationId(req.headers)
@@ -83,6 +84,7 @@ export async function moveHandler(req: HttpRequest): Promise<HttpResponseInit> {
 
     const dir = normalizationResult.canonical
 
+    const locationRepo = await locationRepoPromise
     const from = await locationRepo.get(fromId)
     if (!from) {
         const latencyMs = Date.now() - started

--- a/frontend/api/src/functions/locationLook.ts
+++ b/frontend/api/src/functions/locationLook.ts
@@ -19,7 +19,7 @@ app.http('LocationLook', {
         const started = Date.now()
         const correlationId = extractCorrelationId(req.headers)
         const playerGuid = extractPlayerGuid(req.headers)
-        const repo = getLocationRepository()
+        const repo = await getLocationRepository()
         const id = req.query.get('id') || STARTER_LOCATION_ID
         const loc = await repo.get(id)
         if (!loc) {

--- a/frontend/api/src/functions/playerBootstrap.ts
+++ b/frontend/api/src/functions/playerBootstrap.ts
@@ -14,7 +14,7 @@ const HEADER_PLAYER_GUID = 'x-player-guid'
 export async function playerBootstrap(request: HttpRequest): Promise<HttpResponseInit> {
     const started = Date.now()
     const correlationId = extractCorrelationId(request.headers)
-    const playerRepo = getPlayerRepository()
+    const playerRepo = await getPlayerRepository()
     const existing = request.headers.get(HEADER_PLAYER_GUID) || undefined
     trackGameEventStrict('Onboarding.GuestGuid.Started', {}, { correlationId })
     const { record, created } = await playerRepo.getOrCreate(existing)

--- a/frontend/api/src/functions/playerCreate.ts
+++ b/frontend/api/src/functions/playerCreate.ts
@@ -15,7 +15,7 @@ app.http('PlayerCreate', {
     handler: async (req: HttpRequest): Promise<HttpResponseInit> => {
         const started = Date.now()
         const correlationId = extractCorrelationId(req.headers)
-        const repo = getPlayerRepository()
+        const repo = await getPlayerRepository()
         const result = await ensurePlayerForRequest(req.headers, repo)
         if (result.created) {
             const latencyMs = Date.now() - started

--- a/frontend/api/src/functions/playerGet.ts
+++ b/frontend/api/src/functions/playerGet.ts
@@ -8,7 +8,7 @@ app.http('PlayerGet', {
     handler: async (req: HttpRequest): Promise<HttpResponseInit> => {
         const started = Date.now()
         const correlationId = extractCorrelationId(req.headers)
-        const repo = getPlayerRepository()
+        const repo = await getPlayerRepository()
         const id = req.query.get('id') || req.headers.get('x-player-guid') || undefined
         if (!id) {
             const body = err('MissingPlayerId', 'Player id or x-player-guid header required', correlationId)

--- a/frontend/api/src/functions/playerLink.ts
+++ b/frontend/api/src/functions/playerLink.ts
@@ -18,7 +18,7 @@ interface LinkResponseBody {
 
 export async function playerLink(request: HttpRequest): Promise<HttpResponseInit> {
     const started = Date.now()
-    const playerRepo = getPlayerRepository()
+    const playerRepo = await getPlayerRepository()
     let body: LinkRequestBody = {}
     try {
         body = (await request.json()) as LinkRequestBody

--- a/frontend/api/src/functions/playerMove.ts
+++ b/frontend/api/src/functions/playerMove.ts
@@ -12,7 +12,7 @@ import {
 } from '@atlas/shared'
 import { app, HttpRequest, HttpResponseInit } from '@azure/functions'
 
-const repo = getLocationRepository()
+const repoPromise = getLocationRepository()
 const headingStore = getPlayerHeadingStore()
 
 app.http('PlayerMove', {
@@ -58,6 +58,7 @@ app.http('PlayerMove', {
 
         const dir = normalizationResult.canonical
 
+        const repo = await repoPromise
         const from = await repo.get(fromId)
         if (!from) {
             const latencyMs = Date.now() - started

--- a/shared/src/persistenceConfig.ts
+++ b/shared/src/persistenceConfig.ts
@@ -25,25 +25,8 @@ export function resolvePersistenceMode(): PersistenceMode {
  * For production, use loadPersistenceConfigAsync which fetches from Key Vault.
  * @deprecated Use loadPersistenceConfigAsync for production workloads
  */
-export function loadPersistenceConfig(): PersistenceConfig {
-    const mode = resolvePersistenceMode()
-    if (mode === 'cosmos') {
-        const endpoint = process.env.COSMOS_GREMLIN_ENDPOINT
-        const database = process.env.COSMOS_GREMLIN_DATABASE
-        const graph = process.env.COSMOS_GREMLIN_GRAPH
-        const key = process.env.COSMOS_GREMLIN_KEY
-        const strict = process.env.PERSISTENCE_STRICT === '1' || process.env.PERSISTENCE_STRICT === 'true'
-        if (!endpoint || !database || !graph) {
-            if (strict) {
-                throw new Error('PERSISTENCE_STRICT enabled but Cosmos Gremlin configuration incomplete (endpoint/database/graph).')
-            }
-            // Fall back to memory if misconfigured (non-strict mode only)
-            return { mode: 'memory' }
-        }
-        return { mode, cosmos: { endpoint, database, graph, key } }
-    }
-    return { mode: 'memory' }
-}
+// Deprecated synchronous loader removed (previously loadPersistenceConfig). All code paths
+// should migrate to the async variant below which sources secrets via Key Vault helper.
 /**
  * Load persistence configuration asynchronously, fetching secrets from Key Vault via managed identity
  * Falls back to environment variables for local development

--- a/shared/src/repos/locationRepository.ts
+++ b/shared/src/repos/locationRepository.ts
@@ -2,7 +2,7 @@ import starterLocationsData from '../data/villageLocations.json' with { type: 'j
 import { isDirection } from '../domainModels.js'
 import { createGremlinClient } from '../gremlin/gremlinClient.js'
 import { Location } from '../location.js'
-import { loadPersistenceConfig, resolvePersistenceMode } from '../persistenceConfig.js'
+import { loadPersistenceConfigAsync, resolvePersistenceMode } from '../persistenceConfig.js'
 import { CosmosLocationRepository } from './locationRepository.cosmos.js'
 
 // Repository contract isolates persistence (memory, cosmos, etc.) from handlers & AI tools.
@@ -70,14 +70,14 @@ class InMemoryLocationRepository implements ILocationRepository {
 }
 
 let singleton: ILocationRepository | undefined
-export function getLocationRepository(): ILocationRepository {
+export async function getLocationRepository(): Promise<ILocationRepository> {
     if (singleton) return singleton
     const mode = resolvePersistenceMode()
     if (mode === 'cosmos') {
         const strict =
             typeof process !== 'undefined' && (process.env.PERSISTENCE_STRICT === '1' || process.env.PERSISTENCE_STRICT === 'true')
         try {
-            const cfg = loadPersistenceConfig()
+            const cfg = await loadPersistenceConfigAsync()
             if (cfg.mode === 'cosmos' && cfg.cosmos) {
                 const pending = createGremlinClient(cfg.cosmos)
                 const proxy: ILocationRepository = {

--- a/shared/src/repos/playerRepository.ts
+++ b/shared/src/repos/playerRepository.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 import { createGremlinClient } from '../gremlin/gremlinClient.js'
 import { STARTER_LOCATION_ID } from '../location.js'
-import { loadPersistenceConfig, resolvePersistenceMode } from '../persistenceConfig.js'
+import { loadPersistenceConfigAsync, resolvePersistenceMode } from '../persistenceConfig.js'
 import { CosmosPlayerRepository } from './playerRepository.cosmos.js'
 
 export interface PlayerRecord {
@@ -73,14 +73,14 @@ class InMemoryPlayerRepository implements IPlayerRepository {
 }
 
 let playerRepoSingleton: IPlayerRepository | undefined
-export function getPlayerRepository(): IPlayerRepository {
+export async function getPlayerRepository(): Promise<IPlayerRepository> {
     if (playerRepoSingleton) return playerRepoSingleton
     const mode = resolvePersistenceMode()
     if (mode === 'cosmos') {
         const strict =
             typeof process !== 'undefined' && (process.env.PERSISTENCE_STRICT === '1' || process.env.PERSISTENCE_STRICT === 'true')
         try {
-            const cfg = loadPersistenceConfig()
+            const cfg = await loadPersistenceConfigAsync()
             if (cfg.mode === 'cosmos' && cfg.cosmos) {
                 const pending = createGremlinClient(cfg.cosmos)
                 const proxy: IPlayerRepository = {

--- a/shared/src/seeding/seedWorld.ts
+++ b/shared/src/seeding/seedWorld.ts
@@ -24,8 +24,8 @@ export interface SeedWorldResult {
 export async function seedWorld(opts: SeedWorldOptions = {}): Promise<SeedWorldResult> {
     const blueprint: Location[] = (opts.blueprint || (starterLocationsData as Location[])).map((l) => ({ ...l }))
     const log = opts.log || (() => {})
-    const locRepo = getLocationRepository()
-    const playerRepo = getPlayerRepository()
+    const locRepo = await getLocationRepository()
+    const playerRepo = await getPlayerRepository()
 
     let locationVerticesCreated = 0
     let exitsCreated = 0

--- a/shared/test/playerAuth.test.ts
+++ b/shared/test/playerAuth.test.ts
@@ -41,7 +41,7 @@ test('parseClientPrincipal returns object for valid header', () => {
 
 test('ensurePlayerForRequest creates and reuses player for SWA principal', async () => {
     __resetPlayerRepositoryForTests()
-    const repo = getPlayerRepository()
+    const repo = await getPlayerRepository()
     const { b64 } = makePrincipalPayload({ userId: 'UserXYZ' })
     const headers1 = new HeaderBag()
     headers1.set('x-ms-client-principal', b64)


### PR DESCRIPTION
### Summary
Removes the deprecated synchronous persistence configuration path and completes the planned lint tightening around secret access.

### Changes
- Remove `loadPersistenceConfig()` implementation (fully deprecated) and rely solely on `loadPersistenceConfigAsync()`.
- Convert `getPlayerRepository()` and `getLocationRepository()` to async (returning Promises) and update all call sites in API handlers, MCP endpoint, seeding, and tests.
- Remove the temporary allowance for `persistenceConfig.ts` in `no-direct-secret-access` ESLint rule.
- Adjust tests to await async repo getters; cleaned up unused context args in `playerLink` tests.
- Minor formatting / indentation fixes after refactor.

### Rationale
This finalizes the deprecation of direct synchronous secret access and ensures all future secret retrieval flows through the centralized async helper (enabling Key Vault / managed identity usage consistently). The ESLint rule now actively prevents regressions.

### Verification
- `npm run lint` passes (no remaining formatting or rule violations).
- `npm run typecheck` passes (no type errors after async migrations).
- `npm run test` passes: 108 total tests (shared + api + backend) all green.

### Migration Notes
External consumers (if any) that imported the previously synchronous repository getters must now `await` them. Internal mono-repo call sites have been updated.

### Follow Ups (Optional)
- Add brief note to developer workflow docs about async repository getter pattern.
- Consider an ESLint rule to forbid introducing new sync secret-bearing config loaders.

Let me know if you’d like a docs PR as a follow-up.
