### PR TITLE
feat(player): Player persistence enhancement (Issue #103)

### DIFF
--- a/backend/test/playerRepositoryIdentity.test.ts
+++ b/backend/test/playerRepositoryIdentity.test.ts
@@ -1,0 +1,28 @@
+import { __resetPlayerRepositoryForTests, getPlayerRepository } from '@atlas/shared'
+import assert from 'node:assert'
+import { test } from 'node:test'
+
+test('player repository stable identity upsert semantics', async () => {
+    __resetPlayerRepositoryForTests()
+    const repo = await getPlayerRepository()
+    const fixedId = '11111111-1111-4111-8111-111111111111'
+    const first = await repo.getOrCreate(fixedId)
+    assert.ok(first.created, 'expected first creation to report created=true')
+    assert.strictEqual(first.record.id, fixedId, 'id should match supplied fixed id')
+    const second = await repo.getOrCreate(fixedId)
+    assert.ok(!second.created, 'expected second call with same id to not create new record')
+    assert.strictEqual(second.record.id, fixedId, 'second retrieval should preserve id')
+})
+
+test('linkExternalId updates guest flag and sets updatedUtc', async () => {
+    __resetPlayerRepositoryForTests()
+    const repo = await getPlayerRepository()
+    const { record } = await repo.getOrCreate()
+    const ext = 'external-sub-123'
+    const result = await repo.linkExternalId(record.id, ext)
+    assert.ok(result.updated, 'expected update to succeed')
+    assert.ok(result.record, 'expected updated record returned')
+    assert.strictEqual(result.record!.externalId, ext, 'externalId should be set')
+    assert.strictEqual(result.record!.guest, false, 'guest should be false after linking external identity')
+    assert.ok(result.record!.updatedUtc, 'updatedUtc should be populated after mutation')
+})

--- a/shared/src/repos/playerRepository.cosmos.ts
+++ b/shared/src/repos/playerRepository.cosmos.ts
@@ -23,13 +23,21 @@ export class CosmosPlayerRepository implements IPlayerRepository {
         // The preliminary get above is sufficient; no need for a second existence check.
         const createdIso = new Date().toISOString()
         await this.client.submit(
-            `g.V(pid).hasLabel('player').fold().coalesce(unfold(), addV('player')
-                .property('id', pid)
-                .property('${WORLD_GRAPH_PARTITION_KEY_PROP}', pk)
-                .property('createdUtc', created)
-                .property('updatedUtc', created)
-                .property('guest', true)
-                .property('currentLocationId', startLoc))`,
+            `
+                g.V(pid)
+                    .hasLabel('player')
+                    .fold()
+                    .coalesce(
+                        unfold(),
+                        addV('player')
+                            .property('id', pid)
+                            .property('${WORLD_GRAPH_PARTITION_KEY_PROP}', pk)
+                            .property('createdUtc', created)
+                            .property('updatedUtc', created)
+                            .property('guest', true)
+                            .property('currentLocationId', startLoc)
+                    )
+            `,
             {
                 pid: newId,
                 pk: WORLD_GRAPH_PARTITION_VALUE,

--- a/shared/src/repos/playerRepository.cosmos.ts
+++ b/shared/src/repos/playerRepository.cosmos.ts
@@ -20,9 +20,7 @@ export class CosmosPlayerRepository implements IPlayerRepository {
         }
         const newId = id || cryptoRandomUUID()
         // Upsert pattern (fold + coalesce) avoids duplicate vertex creation races for the same supplied id.
-        // We still perform a preliminary get for fast path and clarity of created flag.
-        const existingFast = await (id ? this.get(id) : Promise.resolve(undefined))
-        if (existingFast) return { record: existingFast, created: false }
+        // The preliminary get above is sufficient; no need for a second existence check.
         const createdIso = new Date().toISOString()
         await this.client.submit(
             `g.V(pid).hasLabel('player').fold().coalesce(unfold(), addV('player')

--- a/shared/src/repos/playerRepository.ts
+++ b/shared/src/repos/playerRepository.ts
@@ -54,6 +54,8 @@ class InMemoryPlayerRepository implements IPlayerRepository {
         if (!rec) return { updated: false }
         rec.externalId = externalId
         rec.guest = false
+        // Track mutation timestamp for analytics / future conflict resolution logic.
+        rec.updatedUtc = new Date().toISOString()
         return { updated: true, record: rec }
     }
     async findByExternalId(externalId: string) {


### PR DESCRIPTION
## Summary
Implements initial scope for Issue #103 (Player Persistence Enhancement).

### Changes
- Add `updatedUtc` mutation timestamp to in‑memory player repository on external identity link
- Cosmos player repository: introduce fold+coalesce upsert pattern to avoid duplicate vertex creation races
- Cosmos player repository: add `updatedUtc` on creation + when linking external identity
- Map `updatedUtc` from Gremlin vertex to `PlayerRecord`
- New tests:
  - Stable identity (second `getOrCreate` with same id returns `created=false`)
  - `linkExternalId` sets `externalId`, flips `guest=false`, and populates `updatedUtc`

### Rationale
Establishes groundwork for stable player identity and idempotent creation ahead of fuller location persistence (#100 dependency). Ensures mutation timeline tracking for future conflict resolution or audit flows.

### Risk
Tag: LOW (localized repository logic; no public API signature changes). Upsert query introduces Gremlin pattern but guarded by existing tests and remains additive.

### Assumptions
- A1: Player vertices already acceptable in world graph (confidence: medium) → Mitigation: Keep change minimal; adjust if ADR updates remove player vertices.
- A2: Race avoidance via Gremlin fold+coalesce sufficient for current scale (confidence: high) → Mitigation: Future telemetry on duplicate creation can revisit.

### Tests
All existing tests pass; added 2 new tests (identity + link external). Total test count increased accordingly.

### Next Steps (Future PRs)
- Integrate with enhanced location persistence once Issue #100 lands (e.g., explicit (player)-[:in]->(location) edge)
- Add repository method for updating player current location with `updatedUtc`
- Consider telemetry event for external identity linkage (`Auth.Player.Upgraded`) if not already emitted upstream.

Closes #103 (or progresses toward closure if more scope later).