### PR TITLE
feat(build-telemetry): Stage 1 ordering validation events & DRY artifact utilities (#104)

### DIFF
--- a/scripts/assign-impl-order.mjs
+++ b/scripts/assign-impl-order.mjs
@@ -48,17 +48,12 @@
  */
 
 import { createHash } from 'node:crypto'
-import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
-import {
-    emitOrderingEvent,
-    flushBuildTelemetry,
-    initBuildTelemetry,
-    trackOrderingApplied,
-    trackOrderingLowConfidence
-} from './shared/build-telemetry.mjs'
+import { emitOrderingEvent, flushBuildTelemetry, initBuildTelemetry, trackOrderingApplied, trackOrderingLowConfidence } from './shared/build-telemetry.mjs'
+import { pruneOldArtifacts } from './shared/ordering-artifacts.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
@@ -398,29 +393,7 @@ function computeScore(issue) {
  * @param {number} keepCount - Number of recent files to keep
  * @param {string} directory - Directory to prune (defaults to ARTIFACTS_DIR)
  */
-function pruneOldArtifacts(keepCount = 200, directory = null) {
-    try {
-        const targetDir = directory || ARTIFACTS_DIR
-        const files = readdirSync(targetDir)
-            .filter((f) => f.endsWith('.json'))
-            .map((f) => ({
-                name: f,
-                path: join(targetDir, f),
-                mtime: statSync(join(targetDir, f)).mtime
-            }))
-            .sort((a, b) => b.mtime - a.mtime) // newest first
-
-        if (files.length > keepCount) {
-            const toDelete = files.slice(keepCount)
-            console.error(`Pruning ${toDelete.length} old artifact file(s)`)
-            for (const file of toDelete) {
-                unlinkSync(file.path)
-            }
-        }
-    } catch (err) {
-        console.error(`Warning: Failed to prune old artifacts: ${err.message}`)
-    }
-}
+// pruneOldArtifacts now centralized in scripts/shared/ordering-artifacts.mjs
 
 /**
  * Check ordering integrity for gaps and duplicates.

--- a/scripts/detect-ordering-overrides.mjs
+++ b/scripts/detect-ordering-overrides.mjs
@@ -14,108 +14,21 @@
  * Looks for changes where automation applied an order and it was manually changed within 24h.
  */
 
-import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { initBuildTelemetry, trackOrderingOverridden, emitOrderingEvent, flushBuildTelemetry } from './shared/build-telemetry.mjs'
+import { loadArtifacts, detectOverrides } from './shared/ordering-artifacts.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const ARTIFACTS_DIR = join(ROOT, 'artifacts', 'ordering')
 
-/**
- * Load all artifact files sorted by timestamp (newest first)
- */
-function loadArtifacts() {
-    try {
-        const files = readdirSync(ARTIFACTS_DIR)
-            .filter((f) => f.endsWith('.json'))
-            .map((f) => ({
-                name: f,
-                path: join(ARTIFACTS_DIR, f),
-                mtime: statSync(join(ARTIFACTS_DIR, f)).mtime
-            }))
-            .sort((a, b) => b.mtime - a.mtime) // newest first
-
-        return files
-            .map((f) => {
-                try {
-                    const content = JSON.parse(readFileSync(f.path, 'utf-8'))
-                    return { ...content, _filename: f.name, _mtime: f.mtime }
-                } catch (err) {
-                    console.error(`Warning: Failed to parse ${f.name}: ${err.message}`)
-                    return null
-                }
-            })
-            .filter(Boolean)
-    } catch (err) {
-        console.error(`Warning: Failed to load artifacts: ${err.message}`)
-        return []
-    }
-}
-
-/**
- * Detect overrides by comparing artifacts
- * Returns array of override events
- */
-function detectOverrides(artifacts) {
-    const overrides = []
-
-    // Group artifacts by issue number
-    const byIssue = new Map()
-    for (const artifact of artifacts) {
-        if (!byIssue.has(artifact.issue)) {
-            byIssue.set(artifact.issue, [])
-        }
-        byIssue.get(artifact.issue).push(artifact)
-    }
-
-    // For each issue, check for overrides
-    for (const [issueNumber, issueArtifacts] of byIssue.entries()) {
-        // Sort by timestamp (newest first)
-        issueArtifacts.sort((a, b) => {
-            const timeA = new Date(a.metadata?.timestamp || 0)
-            const timeB = new Date(b.metadata?.timestamp || 0)
-            return timeB - timeA
-        })
-
-        // Look for pattern: automation applied (applied=true) -> then different recommendedOrder within 24h
-        for (let i = 0; i < issueArtifacts.length - 1; i++) {
-            const current = issueArtifacts[i]
-            const previous = issueArtifacts[i + 1]
-
-            // Skip if previous wasn't applied by automation
-            if (!previous.applied) continue
-
-            // Check if orders differ
-            if (current.recommendedOrder !== previous.recommendedOrder) {
-                // Calculate time difference
-                const currentTime = new Date(current.metadata?.timestamp || 0)
-                const previousTime = new Date(previous.metadata?.timestamp || 0)
-                const hoursDiff = (currentTime - previousTime) / (1000 * 60 * 60)
-
-                // Only flag if within 24 hours
-                if (hoursDiff <= 24 && hoursDiff >= 0) {
-                    overrides.push({
-                        issueNumber,
-                        previousOrder: previous.recommendedOrder,
-                        manualOrder: current.recommendedOrder,
-                        hoursSinceAutomation: Math.round(hoursDiff * 10) / 10,
-                        automationTimestamp: previous.metadata?.timestamp || 'unknown'
-                    })
-                }
-            }
-        }
-    }
-
-    return overrides
-}
 
 async function main() {
     initBuildTelemetry()
 
     console.log('Detecting ordering overrides...')
-    const artifacts = loadArtifacts()
+    const artifacts = loadArtifacts(ARTIFACTS_DIR)
     console.log(`Loaded ${artifacts.length} artifact(s)`)
 
     if (artifacts.length < 2) {

--- a/scripts/shared/build-telemetry.mjs
+++ b/scripts/shared/build-telemetry.mjs
@@ -68,14 +68,16 @@ export function emitBuildEvent(name, props = {}) {
 }
 
 // Validation helpers (Stage 1 integrity)
+const ORDERING_VALIDATION_PROPS = { telemetryType: 'ordering', stage: 1 }
+
 export function trackValidationStart(props = {}) {
-    emitOrderingEvent('validation.start', { ...props, telemetryType: 'ordering', stage: 1 })
+    emitOrderingEvent('validation.start', { ...props, ...ORDERING_VALIDATION_PROPS })
 }
 export function trackValidationSuccess(props = {}) {
-    emitOrderingEvent('validation.success', { ...props, telemetryType: 'ordering', stage: 1 })
+    emitOrderingEvent('validation.success', { ...props, ...ORDERING_VALIDATION_PROPS })
 }
 export function trackValidationFail(props = {}) {
-    emitOrderingEvent('validation.fail', { ...props, telemetryType: 'ordering', stage: 1 })
+    emitOrderingEvent('validation.fail', { ...props, ...ORDERING_VALIDATION_PROPS })
 }
 
 /**

--- a/scripts/shared/build-telemetry.mjs
+++ b/scripts/shared/build-telemetry.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
-/* global process, console */
+/* global console */
 /**
  * Build automation telemetry module.
  *
@@ -35,11 +35,47 @@ export const BUILD_EVENT_NAMES = {
     OVERRIDE_DETECTED: 'build.ordering.override.detected',
     INTEGRITY_SNAPSHOT: 'build.ordering.integrity.snapshot',
     METRICS_WEEKLY: 'build.ordering.metrics.weekly',
+    VALIDATION_START: 'build.ordering.validation.start',
+    VALIDATION_SUCCESS: 'build.ordering.validation.success',
+    VALIDATION_FAIL: 'build.ordering.validation.fail',
     // Stage 2 scheduling events
     SCHEDULE_VARIANCE: 'build.schedule_variance',
     PROVISIONAL_SCHEDULE_CREATED: 'build.provisional_schedule_created',
     VARIANCE_ALERT: 'build.variance_alert',
     REBASELINE_TRIGGERED: 'build.rebaseline_triggered'
+}
+
+/**
+ * Generic build event emission (ensures build. prefix).
+ * @param {string} name Full event name (must start with build.)
+ * @param {object} props Additional properties
+ */
+export function emitBuildEvent(name, props = {}) {
+    if (!name.startsWith('build.')) {
+        console.error(`Invalid build event name '${name}' (must start with 'build.')`)
+        return
+    }
+    const event = {
+        name,
+        properties: {
+            ...props,
+            timestamp: new Date().toISOString(),
+            telemetrySource: 'build-automation'
+        }
+    }
+    console.log('[BUILD_TELEMETRY]', JSON.stringify(event, null, 2))
+    eventBuffer.push(event)
+}
+
+// Validation helpers (Stage 1 integrity)
+export function trackValidationStart(props = {}) {
+    emitOrderingEvent('validation.start', { ...props, telemetryType: 'ordering', stage: 1 })
+}
+export function trackValidationSuccess(props = {}) {
+    emitOrderingEvent('validation.success', { ...props, telemetryType: 'ordering', stage: 1 })
+}
+export function trackValidationFail(props = {}) {
+    emitOrderingEvent('validation.fail', { ...props, telemetryType: 'ordering', stage: 1 })
 }
 
 /**

--- a/scripts/shared/ordering-artifacts.mjs
+++ b/scripts/shared/ordering-artifacts.mjs
@@ -133,7 +133,7 @@ export function pruneOldArtifacts(dir, keepCount = 200) {
         const files = listArtifactFiles(dir)
         if (files.length <= keepCount) return
         const toDelete = files.slice(keepCount)
-        console.error(`Pruning ${toDelete.length} old artifact file(s) (keep=${keepCount})`)
+        console.log(`Pruning ${toDelete.length} old artifact file(s) (keep=${keepCount})`)
         for (const f of toDelete) unlinkSync(f.path)
     } catch (err) {
         console.error(`ordering-artifacts: Failed to prune old artifacts: ${err.message}`)

--- a/scripts/shared/ordering-artifacts.mjs
+++ b/scripts/shared/ordering-artifacts.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/*
+ * Shared ordering artifact utilities (build automation only).
+ * DRY consolidation of repeated logic in ordering-related scripts:
+ *  - Loading/parsing artifact JSON files
+ *  - Time window filtering
+ *  - Override detection (manual change within 24h of automation apply)
+ *  - Pruning old artifacts
+ *
+ * IMPORTANT: Remains in scripts/shared (build layer). Do NOT import from game domain code.
+ */
+
+import { readdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * List artifact file metadata objects for a directory.
+ * @param {string} dir Absolute or relative path to artifacts directory
+ * @returns {Array<{name:string,path:string,mtime:Date}>}
+ */
+export function listArtifactFiles(dir) {
+    try {
+        return readdirSync(dir)
+            .filter((f) => f.endsWith('.json'))
+            .map((f) => {
+                const path = join(dir, f)
+                return { name: f, path, mtime: statSync(path).mtime }
+            })
+            .sort((a, b) => b.mtime - a.mtime)
+    } catch (err) {
+        console.error(`ordering-artifacts: Failed to list artifacts in ${dir}: ${err.message}`)
+        return []
+    }
+}
+
+/**
+ * Parse artifact JSON files to objects, skipping invalid ones.
+ * @param {Array<{name:string,path:string,mtime:Date}>} files
+ * @returns {Array<object>} parsed artifacts with _filename/_mtime
+ */
+export function parseArtifacts(files) {
+    const parsed = []
+    for (const f of files) {
+        try {
+            const content = JSON.parse(readFileSync(f.path, 'utf-8'))
+            parsed.push({ ...content, _filename: f.name, _mtime: f.mtime })
+        } catch (err) {
+            console.error(`ordering-artifacts: Skipping invalid artifact ${f.name}: ${err.message}`)
+        }
+    }
+    return parsed
+}
+
+/**
+ * Load artifacts optionally limited to a time window.
+ * @param {string} dir Artifacts directory
+ * @param {object} [opts]
+ * @param {number} [opts.daysBack] Include only artifacts newer than now - daysBack (whole days)
+ */
+export function loadArtifacts(dir, opts = {}) {
+    const { daysBack } = opts
+    let files = listArtifactFiles(dir)
+    if (daysBack && daysBack > 0) {
+        const cutoff = Date.now() - daysBack * 24 * 60 * 60 * 1000
+        files = files.filter((f) => f.mtime.getTime() >= cutoff)
+    }
+    return parseArtifacts(files)
+}
+
+/**
+ * Group artifacts by issue number property.
+ * @param {Array<object>} artifacts
+ * @returns {Map<number, Array<object>>}
+ */
+export function groupArtifactsByIssue(artifacts) {
+    const map = new Map()
+    for (const art of artifacts) {
+        if (typeof art.issue !== 'number') continue
+        if (!map.has(art.issue)) map.set(art.issue, [])
+        map.get(art.issue).push(art)
+    }
+    return map
+}
+
+/**
+ * Detect manual overrides: change in recommendedOrder within 24h after an applied artifact.
+ * @param {Array<object>} artifacts
+ * @returns {Array<object>} override events
+ */
+export function detectOverrides(artifacts) {
+    const overrides = []
+    const byIssue = groupArtifactsByIssue(artifacts)
+    for (const [issueNumber, issueArtifacts] of byIssue.entries()) {
+        issueArtifacts.sort((a, b) => new Date(b.metadata?.timestamp || 0) - new Date(a.metadata?.timestamp || 0))
+        for (let i = 0; i < issueArtifacts.length - 1; i++) {
+            const current = issueArtifacts[i]
+            const previous = issueArtifacts[i + 1]
+            if (!previous.applied) continue
+            if (current.recommendedOrder === previous.recommendedOrder) continue
+            const currentTime = new Date(current.metadata?.timestamp || 0)
+            const previousTime = new Date(previous.metadata?.timestamp || 0)
+            const hoursDiff = (currentTime - previousTime) / (1000 * 60 * 60)
+            if (hoursDiff <= 24 && hoursDiff >= 0) {
+                overrides.push({
+                    issueNumber,
+                    previousOrder: previous.recommendedOrder,
+                    manualOrder: current.recommendedOrder,
+                    hoursSinceAutomation: Math.round(hoursDiff * 10) / 10,
+                    automationTimestamp: previous.metadata?.timestamp || 'unknown'
+                })
+            }
+        }
+    }
+    return overrides
+}
+
+/**
+ * Count overrides derived from artifacts array.
+ * @param {Array<object>} artifacts
+ */
+export function countOverrides(artifacts) {
+    return detectOverrides(artifacts).length
+}
+
+/**
+ * Prune old artifact files keeping most recent N.
+ * @param {string} dir
+ * @param {number} keepCount
+ */
+export function pruneOldArtifacts(dir, keepCount = 200) {
+    try {
+        const files = listArtifactFiles(dir)
+        if (files.length <= keepCount) return
+        const toDelete = files.slice(keepCount)
+        console.error(`Pruning ${toDelete.length} old artifact file(s) (keep=${keepCount})`)
+        for (const f of toDelete) unlinkSync(f.path)
+    } catch (err) {
+        console.error(`ordering-artifacts: Failed to prune old artifacts: ${err.message}`)
+    }
+}
+
+export default {
+    listArtifactFiles,
+    parseArtifacts,
+    loadArtifacts,
+    groupArtifactsByIssue,
+    detectOverrides,
+    countOverrides,
+    pruneOldArtifacts
+}

--- a/scripts/weekly-ordering-metrics.mjs
+++ b/scripts/weekly-ordering-metrics.mjs
@@ -18,10 +18,10 @@
  */
 
 import { parseArgs } from 'node:util'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { emitOrderingEvent } from './shared/build-telemetry.mjs'
+import { loadArtifacts, countOverrides } from './shared/ordering-artifacts.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
@@ -35,40 +35,6 @@ const { values } = parseArgs({
 
 const DAYS = Number(values.days)
 
-/**
- * Load artifacts from the specified time window
- */
-function loadArtifacts(daysBack) {
-    try {
-        const cutoffTime = Date.now() - daysBack * 24 * 60 * 60 * 1000
-        const files = readdirSync(ARTIFACTS_DIR)
-            .filter((f) => f.endsWith('.json'))
-            .map((f) => {
-                const path = join(ARTIFACTS_DIR, f)
-                return {
-                    name: f,
-                    path,
-                    mtime: statSync(path).mtime
-                }
-            })
-            .filter((f) => f.mtime.getTime() >= cutoffTime)
-
-        return files
-            .map((f) => {
-                try {
-                    const content = JSON.parse(readFileSync(f.path, 'utf-8'))
-                    return { ...content, _filename: f.name, _mtime: f.mtime }
-                } catch (err) {
-                    console.error(`Warning: Failed to parse ${f.name}: ${err.message}`)
-                    return null
-                }
-            })
-            .filter(Boolean)
-    } catch (err) {
-        console.error(`Warning: Failed to load artifacts: ${err.message}`)
-        return []
-    }
-}
 
 /**
  * Calculate metrics from artifacts
@@ -79,41 +45,7 @@ function calculateMetrics(artifacts) {
     const mediumConfidence = artifacts.filter((a) => a.confidence === 'medium')
     const lowConfidence = artifacts.filter((a) => a.confidence === 'low')
     const applied = artifacts.filter((a) => a.applied === true)
-
-    // Calculate override rate by grouping by issue
-    const byIssue = new Map()
-    for (const artifact of artifacts) {
-        if (!byIssue.has(artifact.issue)) {
-            byIssue.set(artifact.issue, [])
-        }
-        byIssue.get(artifact.issue).push(artifact)
-    }
-
-    let overrideCount = 0
-    for (const [, issueArtifacts] of byIssue.entries()) {
-        issueArtifacts.sort((a, b) => {
-            const timeA = new Date(a.metadata?.timestamp || 0)
-            const timeB = new Date(b.metadata?.timestamp || 0)
-            return timeB - timeA
-        })
-
-        for (let i = 0; i < issueArtifacts.length - 1; i++) {
-            const current = issueArtifacts[i]
-            const previous = issueArtifacts[i + 1]
-
-            if (!previous.applied) continue
-            if (current.recommendedOrder !== previous.recommendedOrder) {
-                const currentTime = new Date(current.metadata?.timestamp || 0)
-                const previousTime = new Date(previous.metadata?.timestamp || 0)
-                const hoursDiff = (currentTime - previousTime) / (1000 * 60 * 60)
-
-                if (hoursDiff <= 24 && hoursDiff >= 0) {
-                    overrideCount++
-                }
-            }
-        }
-    }
-
+    const overrideCount = countOverrides(artifacts)
     return {
         totalProcessed,
         highConfidence: highConfidence.length,
@@ -133,7 +65,7 @@ async function main() {
     console.log(`Period: Last ${DAYS} days`)
     console.log('')
 
-    const artifacts = loadArtifacts(DAYS)
+    const artifacts = loadArtifacts(ARTIFACTS_DIR, { daysBack: DAYS })
 
     if (artifacts.length === 0) {
         console.log('ℹ️  No artifacts found in the specified time window.')


### PR DESCRIPTION
Goal: Establish foundational Stage 1 ordering telemetry (validation start/success/fail) and centralize artifact utilities to reduce duplication, enabling future metrics & hardening (#104).

Summary of Changes:
- Added shared module scripts/shared/ordering-artifacts.mjs consolidating artifact load/parse, override detection, pruning, and grouping.
- Extended build telemetry constants with validation events (build.ordering.validation.start|success|fail).
- Added generic emitBuildEvent + validation helper functions (trackValidationStart/Success/Fail).
- Updated check-ordering-integrity.mjs to emit validation lifecycle events and success/fail outcomes.
- Refactored detect-ordering-overrides.mjs & weekly-ordering-metrics.mjs to reuse shared artifact utilities (removed duplicated logic).
- Refactored assign-impl-order.mjs to use centralized pruneOldArtifacts.
- Enhanced test-ordering-telemetry.mjs with validation event assertions and new constants.

Acceptance Criteria Coverage (initial slice for #104):
- [x] Validation start + success + fail events emitted.
- [x] Centralized DRY artifact utilities; removed duplicated override/prune/load logic across scripts.
- [x] Tests cover legacy + granular + new validation events (all passing locally).
- [x] No domain (game) telemetry contamination; all under scripts/.
- [ ] Weekly aggregation extension to include validation pass/fail counts (deferred to follow-up PR).
- [ ] Lint rule tightening for build.* event placement (planned).

Risk Tag: BUILD-SCRIPT (low runtime risk; console+artifact only).

Testing Performed:
- Ran npm run test:ordering (all tests pass) verifying new validation events appear.

Next Steps (subsequent PRs for #104):
1. Extend weekly metrics to aggregate validation success/fail counts and average integrity check size.
2. Add ESLint rule enhancement or script to assert no build.* events outside scripts/.
3. Add a lightweight aggregation artifact for CI consumption.

Please review the scope; this PR intentionally limits changes to additive telemetry + DRY refactor to keep diff approachable.

Closes #104 (will move issue to In progress).