### PR TITLE
fix(shared): unblock publish-shared workflow

### DIFF
--- a/shared/src/prompts/PromptTemplateRepository.ts
+++ b/shared/src/prompts/PromptTemplateRepository.ts
@@ -5,7 +5,7 @@
  * Supports retrieval by id, version, and content hash with TTL-based caching.
  */
 
-import { computeTemplateHash } from './hash.js'
+import { computeContentHash } from './hash.js'
 import type { IPromptTemplateRepository, PromptTemplate, PromptTemplateQuery, PromptCacheConfig } from './types.js'
 import { getWorldTemplate, type WorldPromptKey } from './worldTemplates.js'
 
@@ -116,7 +116,7 @@ export class PromptTemplateRepository implements IPromptTemplateRepository {
 
         try {
             const content = getWorldTemplate(id as WorldPromptKey)
-            const hash = computeTemplateHash(content)
+            const hash = computeContentHash(content)
 
             return {
                 id,

--- a/shared/src/prompts/canonicalize.ts
+++ b/shared/src/prompts/canonicalize.ts
@@ -11,7 +11,7 @@
  */
 
 import crypto from 'node:crypto'
-import type { PromptTemplate } from './schema.js'
+import type { PromptTemplateFile } from './schema.js'
 
 /**
  * Canonicalize a prompt template to deterministic JSON string
@@ -22,7 +22,7 @@ import type { PromptTemplate } from './schema.js'
  * 3. Normalize whitespace in template content
  * 4. Return compact JSON (no extra whitespace)
  */
-export function canonicalizeTemplate(template: PromptTemplate): string {
+export function canonicalizeTemplate(template: PromptTemplateFile): string {
     // Deep sort keys recursively
     const sortedTemplate = sortObjectKeys(template)
 
@@ -35,7 +35,7 @@ export function canonicalizeTemplate(template: PromptTemplate): string {
  *
  * Returns hex-encoded digest for content addressing and version control
  */
-export function computeTemplateHash(template: PromptTemplate): string {
+export function computeTemplateHash(template: PromptTemplateFile): string {
     const canonical = canonicalizeTemplate(template)
     return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex')
 }
@@ -73,7 +73,7 @@ function sortObjectKeys(obj: unknown): unknown {
 /**
  * Verify template hash matches expected value
  */
-export function verifyTemplateHash(template: PromptTemplate, expectedHash: string): boolean {
+export function verifyTemplateHash(template: PromptTemplateFile, expectedHash: string): boolean {
     const actualHash = computeTemplateHash(template)
     return actualHash === expectedHash
 }
@@ -81,7 +81,7 @@ export function verifyTemplateHash(template: PromptTemplate, expectedHash: strin
 /**
  * Batch hash multiple templates
  */
-export function hashTemplates(templates: Record<string, PromptTemplate>): Record<string, string> {
+export function hashTemplates(templates: Record<string, PromptTemplateFile>): Record<string, string> {
     const hashes: Record<string, string> = {}
 
     for (const [id, template] of Object.entries(templates)) {

--- a/shared/src/prompts/hash.ts
+++ b/shared/src/prompts/hash.ts
@@ -11,7 +11,7 @@ import { createHash } from 'crypto'
  * @param content - Template content string
  * @returns Hex-encoded SHA256 hash
  */
-export function computeTemplateHash(content: string): string {
+export function computeContentHash(content: string): string {
     return createHash('sha256').update(content, 'utf8').digest('hex')
 }
 
@@ -21,7 +21,7 @@ export function computeTemplateHash(content: string): string {
  * @param expectedHash - Expected hash value
  * @returns True if hash matches
  */
-export function verifyTemplateHash(content: string, expectedHash: string): boolean {
-    const actualHash = computeTemplateHash(content)
+export function verifyContentHash(content: string, expectedHash: string): boolean {
+    const actualHash = computeContentHash(content)
     return actualHash === expectedHash
 }

--- a/shared/src/prompts/index.ts
+++ b/shared/src/prompts/index.ts
@@ -1,9 +1,9 @@
 // AUTO-GENERATED BARREL: do not edit manually (run scripts/generate-barrels.mjs).
 // Only side-effect-free re-exports allowed here.
-export * from './hash.js'
-export * from './PromptTemplateRepository.js'
-export * from './types.js'
 export * from './canonicalize.js'
+export * from './hash.js'
 export * from './loader.js'
+export * from './PromptTemplateRepository.js'
 export * from './schema.js'
+export * from './types.js'
 export * from './worldTemplates.js'

--- a/shared/src/prompts/schema.ts
+++ b/shared/src/prompts/schema.ts
@@ -15,7 +15,7 @@ import { z } from 'zod'
 /**
  * Prompt template metadata schema
  */
-export const PromptTemplateMetadataSchema = z.object({
+export const PromptTemplateFileMetadataSchema = z.object({
     id: z
         .string()
         .min(1)
@@ -29,7 +29,7 @@ export const PromptTemplateMetadataSchema = z.object({
     createdAt: z.string().datetime().optional(),
     updatedAt: z.string().datetime().optional()
 })
-export type PromptTemplateMetadata = z.infer<typeof PromptTemplateMetadataSchema>
+export type PromptTemplateFileMetadata = z.infer<typeof PromptTemplateFileMetadataSchema>
 
 /**
  * Variable definition schema for template interpolation
@@ -48,8 +48,8 @@ export type VariableDefinition = z.infer<typeof VariableDefinitionSchema>
 /**
  * Complete prompt template schema
  */
-export const PromptTemplateSchema = z.object({
-    metadata: PromptTemplateMetadataSchema,
+export const PromptTemplateFileSchema = z.object({
+    metadata: PromptTemplateFileMetadataSchema,
     template: z.string().min(1).max(50000),
     variables: z.array(VariableDefinitionSchema).optional(),
     examples: z
@@ -62,7 +62,7 @@ export const PromptTemplateSchema = z.object({
         )
         .optional()
 })
-export type PromptTemplate = z.infer<typeof PromptTemplateSchema>
+export type PromptTemplateFile = z.infer<typeof PromptTemplateFileSchema>
 
 /**
  * Bundled prompt templates artifact schema
@@ -70,7 +70,7 @@ export type PromptTemplate = z.infer<typeof PromptTemplateSchema>
 export const PromptBundleSchema = z.object({
     version: z.string(),
     generatedAt: z.string().datetime(),
-    templates: z.record(z.string(), PromptTemplateSchema),
+    templates: z.record(z.string(), PromptTemplateFileSchema),
     hashes: z.record(z.string(), z.string()) // id -> SHA256 hash
 })
 export type PromptBundle = z.infer<typeof PromptBundleSchema>
@@ -78,17 +78,17 @@ export type PromptBundle = z.infer<typeof PromptBundleSchema>
 /**
  * Validation result
  */
-export interface ValidationResult {
+export interface PromptTemplateValidationResult {
     valid: boolean
     errors?: z.ZodError
-    template?: PromptTemplate
+    template?: PromptTemplateFile
 }
 
 /**
  * Validate a prompt template object
  */
-export function validatePromptTemplate(data: unknown): ValidationResult {
-    const result = PromptTemplateSchema.safeParse(data)
+export function validatePromptTemplate(data: unknown): PromptTemplateValidationResult {
+    const result = PromptTemplateFileSchema.safeParse(data)
     if (result.success) {
         return { valid: true, template: result.data }
     }


### PR DESCRIPTION
## Why
The "Publish Shared Package" workflow started failing during `npm run build` due to TypeScript TS2308 export name collisions inside `shared/src/prompts`.

## What changed
- Renamed file-schema prompt types (`PromptTemplateFile*`) to avoid collisions with runtime registry types.
- Renamed string hashing helpers (`computeContentHash`, `verifyContentHash`) to avoid colliding with template-object hashing (`computeTemplateHash`).
- Renamed prompt-schema validation result type (`PromptTemplateValidationResult`) to avoid clashing with `shared/src/utils/validation`.

## Verification
- `npm run build` (shared)
- `npm test` (shared)

## Impact
Unblocks the shared publish action; no functional runtime behavior changes expected.