### PR TITLE
Secure prompt template retrieval (auth, TTL config)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/functions": "^4.9.0",
                 "@azure/identity": "^4.13.0",
                 "@azure/keyvault-secrets": "^4.10.0",
-                "@piquet-h/shared": "^0.3.104",
+                "@piquet-h/shared": "^0.3.108",
                 "@types/marked": "^5.0.2",
                 "applicationinsights": "^2.9.5",
                 "ci": "^2.3.0",
@@ -1453,9 +1453,9 @@
             }
         },
         "node_modules/@piquet-h/shared": {
-            "version": "0.3.104",
-            "resolved": "https://npm.pkg.github.com/download/@piquet-h/shared/0.3.104/2ee9045409dfa40e5a5861adec0ff3e3af53fa3b",
-            "integrity": "sha512-KEWbFEOtRkg4UrEOUG38EMjTARuhRbxnipCJ89M5IRmf800akLhWXSxkr7vmqJNmdP0Djq3r0s44sINmE5J+7A==",
+            "version": "0.3.108",
+            "resolved": "https://npm.pkg.github.com/download/@piquet-h/shared/0.3.108/3a0566d5cb5fff238ecc577328ead63ae6e0cc0f",
+            "integrity": "sha512-3ONMA5Q9x/I3cZPsWx8apus9WtLor0MagUNOQvVe+KoYj8I63w6ptStNGI5X6tjfwpr5zWLSmG+6tLrKVa8alA==",
             "license": "MIT",
             "dependencies": {
                 "zod": "^4.1.12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
         "@azure/functions": "^4.9.0",
         "@azure/identity": "^4.13.0",
         "@azure/keyvault-secrets": "^4.10.0",
-        "@piquet-h/shared": "^0.3.104",
+        "@piquet-h/shared": "^0.3.108",
         "@types/marked": "^5.0.2",
         "applicationinsights": "^2.9.5",
         "ci": "^2.3.0",

--- a/backend/src/config/promptTemplateCacheConfig.ts
+++ b/backend/src/config/promptTemplateCacheConfig.ts
@@ -1,0 +1,40 @@
+/**
+ * Prompt Template Cache Config
+ *
+ * Controls cache headers and in-memory template repository TTL.
+ *
+ * Environment variables:
+ * - PROMPT_TEMPLATE_CACHE_TTL_SECONDS: number of seconds for cache TTL (default 300)
+ *   - set to 0 to disable caching headers + repository caching.
+ */
+
+export interface PromptTemplateCacheConfig {
+    /** TTL in milliseconds for in-memory repository caching. */
+    ttlMs: number
+    /** TTL in seconds for Cache-Control max-age. */
+    maxAgeSeconds: number
+    /** Whether caching is enabled (ttl > 0). */
+    enabled: boolean
+}
+
+const DEFAULT_TTL_SECONDS = 5 * 60
+
+function parseNonNegativeInt(value: string | undefined): number | null {
+    if (value === undefined) return null
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = Number.parseInt(trimmed, 10)
+    if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed < 0) return null
+    return parsed
+}
+
+export function getPromptTemplateCacheConfig(): PromptTemplateCacheConfig {
+    const ttlSeconds = parseNonNegativeInt(process.env.PROMPT_TEMPLATE_CACHE_TTL_SECONDS) ?? DEFAULT_TTL_SECONDS
+
+    const enabled = ttlSeconds > 0
+    return {
+        enabled,
+        maxAgeSeconds: enabled ? ttlSeconds : 0,
+        ttlMs: enabled ? ttlSeconds * 1000 : 0
+    }
+}

--- a/backend/src/functions/getPromptTemplate.ts
+++ b/backend/src/functions/getPromptTemplate.ts
@@ -4,6 +4,6 @@ import { getPromptTemplateHandler } from '../handlers/getPromptTemplate.js'
 app.http('GetPromptTemplate', {
     route: 'prompts/{id}',
     methods: ['GET'],
-    authLevel: 'anonymous',
+    authLevel: 'function',
     handler: getPromptTemplateHandler
 })

--- a/backend/src/handlers/getPromptTemplate.ts
+++ b/backend/src/handlers/getPromptTemplate.ts
@@ -9,6 +9,7 @@ import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/fu
 import type { IPromptTemplateRepository } from '@piquet-h/shared'
 import type { Container } from 'inversify'
 import { inject, injectable } from 'inversify'
+import { getPromptTemplateCacheConfig } from '../config/promptTemplateCacheConfig.js'
 import type { ITelemetryClient } from '../telemetry/ITelemetryClient.js'
 import { BaseHandler } from './base/BaseHandler.js'
 import { errorResponse, okResponse } from './utils/responseBuilder.js'
@@ -87,11 +88,13 @@ export class GetPromptTemplateHandler extends BaseHandler {
             status: 200
         })
 
+        const cacheConfig = getPromptTemplateCacheConfig()
+
         return okResponse(template, {
             correlationId: this.correlationId,
             additionalHeaders: {
                 ETag: template.hash,
-                'Cache-Control': 'public, max-age=300' // 5 minutes
+                'Cache-Control': cacheConfig.enabled ? `public, max-age=${cacheConfig.maxAgeSeconds}` : 'no-store'
             }
         })
     }

--- a/backend/src/inversify.config.ts
+++ b/backend/src/inversify.config.ts
@@ -17,6 +17,7 @@ import { PromptTemplateRepository, SystemClock, type IClock, type IPromptTemplat
 import { Container } from 'inversify'
 import 'reflect-metadata'
 import { EXIT_HINT_DEBOUNCE_MS } from './config/exitHintDebounceConfig.js'
+import { getPromptTemplateCacheConfig } from './config/promptTemplateCacheConfig.js'
 import { GremlinClient, GremlinClientConfig, IGremlinClient } from './gremlin/index.js'
 import { BootstrapPlayerHandler } from './handlers/bootstrapPlayer.js'
 import { ContainerHealthHandler } from './handlers/containerHealth.js'
@@ -250,9 +251,10 @@ export const setupContainer = async (container: Container) => {
     container.bind<IClock>('IClock').toConstantValue(new SystemClock())
 
     // === Prompt Template Repository (file-based, no Cosmos dependency) ===
+    const promptCache = getPromptTemplateCacheConfig()
     container
         .bind<IPromptTemplateRepository>('IPromptTemplateRepository')
-        .toConstantValue(new PromptTemplateRepository({ ttlMs: 5 * 60 * 1000 })) // 5 minute cache
+        .toConstantValue(new PromptTemplateRepository({ ttlMs: promptCache.ttlMs }))
 
     // === Services ===
     container.bind(DescriptionComposer).toSelf().inSingletonScope()

--- a/backend/test/helpers/testInversify.config.ts
+++ b/backend/test/helpers/testInversify.config.ts
@@ -11,7 +11,7 @@
  * - Supports 'cosmos' mode for E2E tests (but still mocks telemetry)
  */
 
-import { PromptTemplateRepository, FakeClock, type IClock, type IPromptTemplateRepository } from '@piquet-h/shared'
+import { FakeClock, PromptTemplateRepository, type IClock, type IPromptTemplateRepository } from '@piquet-h/shared'
 import { Container } from 'inversify'
 import 'reflect-metadata'
 import { EXIT_HINT_DEBOUNCE_MS } from '../../src/config/exitHintDebounceConfig.js'
@@ -80,9 +80,9 @@ import { CosmosWorldEventRepository } from '../../src/repos/worldEventRepository
 import { IWorldEventRepository } from '../../src/repos/worldEventRepository.js'
 import { MemoryWorldEventRepository } from '../../src/repos/worldEventRepository.memory.js'
 import { DescriptionComposer } from '../../src/services/descriptionComposer.js'
-import { RealmService } from '../../src/services/RealmService.js'
 import { LocationClockManager } from '../../src/services/LocationClockManager.js'
 import { PlayerClockService } from '../../src/services/PlayerClockService.js'
+import { RealmService } from '../../src/services/RealmService.js'
 import { ReconcileEngine } from '../../src/services/ReconcileEngine.js'
 import { WorldClockService } from '../../src/services/WorldClockService.js'
 import { ITelemetryClient } from '../../src/telemetry/ITelemetryClient.js'
@@ -92,6 +92,7 @@ import { ExitCreateHandler } from '../../src/worldEvents/handlers/ExitCreateHand
 import { NPCTickHandler } from '../../src/worldEvents/handlers/NPCTickHandler.js'
 import { QueueProcessWorldEventHandler } from '../../src/worldEvents/queueProcessWorldEvent.js'
 // Import mocks from test folder
+import { getPromptTemplateCacheConfig } from '../../src/config/promptTemplateCacheConfig.js'
 import { MockTelemetryClient } from '../mocks/MockTelemetryClient.js'
 import { MockDescriptionRepository } from '../mocks/repositories/descriptionRepository.mock.js'
 import { MockExitRepository } from '../mocks/repositories/exitRepository.mock.js'
@@ -319,9 +320,10 @@ export const setupTestContainer = async (container: Container, mode?: ContainerM
     container.bind<IClock>('IClock').toConstantValue(new FakeClock())
 
     // === Prompt Template Repository (file-based, no Cosmos dependency) ===
+    const promptCache = getPromptTemplateCacheConfig()
     container
         .bind<IPromptTemplateRepository>('IPromptTemplateRepository')
-        .toConstantValue(new PromptTemplateRepository({ ttlMs: 5 * 60 * 1000 })) // 5 minute cache
+        .toConstantValue(new PromptTemplateRepository({ ttlMs: promptCache.ttlMs }))
 
     // Register services (available in all modes)
     container.bind(DescriptionComposer).toSelf().inSingletonScope()

--- a/backend/test/integration/correlationIdFlow.test.ts
+++ b/backend/test/integration/correlationIdFlow.test.ts
@@ -21,6 +21,10 @@ import { UnitTestFixture } from '../helpers/UnitTestFixture.js'
 
 describe('CorrelationId Flow Integration', () => {
     let fixture: UnitTestFixture
+    const TEST_LOCATION_ID = '550e8400-e29b-41d4-a716-446655440000'
+    const TEST_LOCATION_FROM_ID = '550e8400-e29b-41d4-a716-446655440001'
+    const TEST_LOCATION_TO_ID = '550e8400-e29b-41d4-a716-446655440002'
+    const TEST_NPC_ID = '550e8400-e29b-41d4-a716-446655440003'
 
     beforeEach(async () => {
         fixture = new UnitTestFixture()
@@ -39,11 +43,11 @@ describe('CorrelationId Flow Integration', () => {
             // Step 1: Prepare event envelope (as HTTP handler would)
             const emitResult = emitWorldEvent({
                 eventType: 'Player.Move',
-                scopeKey: 'loc:test-location',
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
                 payload: {
-                    playerId: 'player-1',
-                    fromLocationId: 'loc-from',
-                    toLocationId: 'loc-to',
+                    playerId: '550e8400-e29b-41d4-a716-446655440010',
+                    fromLocationId: TEST_LOCATION_FROM_ID,
+                    toLocationId: TEST_LOCATION_TO_ID,
                     direction: 'north'
                 },
                 actor: {
@@ -89,8 +93,8 @@ describe('CorrelationId Flow Integration', () => {
             // Emit event without correlationId (auto-generated)
             const emitResult = emitWorldEvent({
                 eventType: 'Player.Look',
-                scopeKey: 'loc:test-location',
-                payload: { locationId: 'loc-1' },
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
+                payload: { locationId: TEST_LOCATION_ID },
                 actor: { kind: 'player' }
                 // correlationId intentionally omitted
             })
@@ -126,7 +130,7 @@ describe('CorrelationId Flow Integration', () => {
             // Emit event with specific correlationId
             const emitResult = emitWorldEvent({
                 eventType: 'Player.Move',
-                scopeKey: 'loc:test-location',
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
                 payload: { direction: 'north' },
                 actor: { kind: 'player' },
                 correlationId: envelopeCorrelationId
@@ -168,7 +172,7 @@ describe('CorrelationId Flow Integration', () => {
 
             const emitResult = emitWorldEvent({
                 eventType: 'Player.Move',
-                scopeKey: 'loc:test-location',
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
                 payload: {},
                 actor: { kind: 'player' },
                 correlationId,
@@ -205,8 +209,8 @@ describe('CorrelationId Flow Integration', () => {
 
             const emitResult = emitWorldEvent({
                 eventType: 'NPC.Tick',
-                scopeKey: 'loc:npc-location',
-                payload: { npcId: 'npc-1' },
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
+                payload: { npcId: TEST_NPC_ID },
                 actor: { kind: 'system' },
                 correlationId,
                 idempotencyKey: `test-registry-correlation-${Date.now()}`
@@ -231,10 +235,10 @@ describe('CorrelationId Flow Integration', () => {
         test('should include all required applicationProperties for Service Bus', async () => {
             const emitResult = emitWorldEvent({
                 eventType: 'World.Exit.Create',
-                scopeKey: 'loc:source-location',
+                scopeKey: `loc:${TEST_LOCATION_ID}`,
                 payload: {
-                    fromLocationId: 'loc-source',
-                    toLocationId: 'loc-target',
+                    fromLocationId: TEST_LOCATION_FROM_ID,
+                    toLocationId: TEST_LOCATION_TO_ID,
                     direction: 'east'
                 },
                 actor: { kind: 'system' },
@@ -248,7 +252,7 @@ describe('CorrelationId Flow Integration', () => {
             const props = enqueueResult.message.applicationProperties
             assert.strictEqual(props.correlationId, '55555555-5555-4555-8555-555555555555')
             assert.strictEqual(props.eventType, 'World.Exit.Create')
-            assert.strictEqual(props.scopeKey, 'loc:source-location')
+            assert.strictEqual(props.scopeKey, `loc:${TEST_LOCATION_ID}`)
             assert.strictEqual(props.operationId, 'op-12345')
 
             // Verify message-level correlationId

--- a/backend/test/integration/getPromptTemplate.test.ts
+++ b/backend/test/integration/getPromptTemplate.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration tests for GET /api/prompts/{id}
+ *
+ * Issue #626 acceptance criteria:
+ * - retrieves latest or version
+ * - supports ?hash
+ * - supports ETag/304
+ * - 404 not found
+ * - 400 when version+hash both provided
+ */
+
+import type { HttpRequest, InvocationContext } from '@azure/functions'
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import { getPromptTemplateHandler } from '../../src/handlers/getPromptTemplate.js'
+import { IntegrationTestFixture } from '../helpers/IntegrationTestFixture.js'
+import { MockTelemetryClient } from '../mocks/MockTelemetryClient.js'
+
+describe('GET /api/prompts/{id} (GetPromptTemplate) integration', () => {
+    let fixture: IntegrationTestFixture
+    let originalPromptCacheTtlSeconds: string | undefined
+
+    beforeEach(async () => {
+        originalPromptCacheTtlSeconds = process.env.PROMPT_TEMPLATE_CACHE_TTL_SECONDS
+        fixture = new IntegrationTestFixture('memory')
+        await fixture.setup()
+    })
+
+    afterEach(async () => {
+        await fixture.teardown()
+        if (originalPromptCacheTtlSeconds === undefined) {
+            delete process.env.PROMPT_TEMPLATE_CACHE_TTL_SECONDS
+        } else {
+            process.env.PROMPT_TEMPLATE_CACHE_TTL_SECONDS = originalPromptCacheTtlSeconds
+        }
+    })
+
+    async function createMockContext(): Promise<InvocationContext> {
+        const container = await fixture.getContainer()
+        return {
+            invocationId: 'test-invocation',
+            functionName: 'GetPromptTemplate',
+            extraInputs: new Map([['container', container]]),
+            log: () => {},
+            error: () => {},
+            warn: () => {},
+            info: () => {},
+            debug: () => {},
+            trace: () => {}
+        } as unknown as InvocationContext
+    }
+
+    function createMockRequest(options: {
+        params?: Record<string, string>
+        query?: Record<string, string>
+        headers?: Record<string, string>
+    }): HttpRequest {
+        return {
+            method: 'GET',
+            url: 'http://localhost/api/prompts/test',
+            params: options.params || {},
+            query: {
+                get: (key: string) => options.query?.[key] || null
+            },
+            headers: {
+                get: (name: string) => options.headers?.[name] || null
+            }
+        } as unknown as HttpRequest
+    }
+
+    async function getTelemetryClient(): Promise<MockTelemetryClient> {
+        const client = await fixture.getTelemetryClient()
+        return client as MockTelemetryClient
+    }
+
+    test('returns 200 and ETag for known template id (latest)', async () => {
+        const ctx = await createMockContext()
+
+        const telemetry = await getTelemetryClient()
+        telemetry.clear()
+
+        const req = createMockRequest({ params: { id: 'location' } })
+        const res = await getPromptTemplateHandler(req, ctx)
+
+        assert.strictEqual(res.status, 200)
+        const headers = res.headers as Record<string, string>
+        assert.ok(headers?.ETag, 'Should include ETag header')
+        assert.ok(headers?.['Cache-Control']?.includes('max-age='), 'Should include Cache-Control max-age')
+
+        const body = JSON.parse(JSON.stringify(res.jsonBody)) as {
+            success: boolean
+            data?: { id: string; hash: string }
+            error?: { code: string }
+        }
+        assert.strictEqual(body.success, true)
+        assert.ok(body.data)
+        assert.strictEqual(body.data.id, 'location')
+        assert.ok(typeof body.data.hash === 'string' && body.data.hash.length > 0)
+
+        const events = telemetry.events.filter((e) => e.name === 'PromptTemplate.Get')
+        assert.strictEqual(events.length, 1)
+        assert.ok(events[0].properties)
+        assert.strictEqual(events[0].properties.status, 200)
+    })
+
+    test('respects PROMPT_TEMPLATE_CACHE_TTL_SECONDS for Cache-Control max-age', async () => {
+        process.env.PROMPT_TEMPLATE_CACHE_TTL_SECONDS = '12'
+
+        // Re-create fixture so DI picks up the new TTL for repo caching too.
+        await fixture.teardown()
+        fixture = new IntegrationTestFixture('memory')
+        await fixture.setup()
+
+        const ctx = await createMockContext()
+
+        const req = createMockRequest({ params: { id: 'location' } })
+        const res = await getPromptTemplateHandler(req, ctx)
+
+        assert.strictEqual(res.status, 200)
+        const headers = res.headers as Record<string, string>
+        assert.strictEqual(headers['Cache-Control'], 'public, max-age=12')
+    })
+
+    test('returns 304 when If-None-Match matches template hash', async () => {
+        const ctx = await createMockContext()
+
+        // First call to get ETag/hash
+        const first = await getPromptTemplateHandler(createMockRequest({ params: { id: 'location' } }), ctx)
+        assert.strictEqual(first.status, 200)
+        const etag = (first.headers as Record<string, string>).ETag
+        assert.ok(etag)
+
+        const telemetry = await getTelemetryClient()
+        telemetry.clear()
+
+        const req = createMockRequest({ params: { id: 'location' }, headers: { 'if-none-match': etag } })
+        const res = await getPromptTemplateHandler(req, ctx)
+
+        assert.strictEqual(res.status, 304)
+        const headers = res.headers as Record<string, string>
+        assert.strictEqual(headers.ETag, etag)
+        assert.ok(headers['x-correlation-id'])
+
+        const events = telemetry.events.filter((e) => e.name === 'PromptTemplate.Get')
+        assert.strictEqual(events.length, 1)
+        assert.ok(events[0].properties)
+        assert.strictEqual(events[0].properties.status, 304)
+        assert.strictEqual(events[0].properties.cached, true)
+    })
+
+    test('returns 400 when both version and hash provided', async () => {
+        const ctx = await createMockContext()
+
+        const req = createMockRequest({
+            params: { id: 'location' },
+            query: { version: '1.0.0', hash: 'deadbeef' }
+        })
+        const res = await getPromptTemplateHandler(req, ctx)
+
+        assert.strictEqual(res.status, 400)
+        const body = JSON.parse(JSON.stringify(res.jsonBody)) as {
+            success: boolean
+            error?: { code: string }
+        }
+        assert.strictEqual(body.success, false)
+        assert.ok(body.error)
+        assert.strictEqual(body.error.code, 'ConflictingParameters')
+    })
+
+    test('returns 404 for unknown template id', async () => {
+        const ctx = await createMockContext()
+
+        const req = createMockRequest({ params: { id: 'definitely-not-a-template' } })
+        const res = await getPromptTemplateHandler(req, ctx)
+
+        assert.strictEqual(res.status, 404)
+        const body = JSON.parse(JSON.stringify(res.jsonBody)) as {
+            success: boolean
+            error?: { code: string }
+        }
+        assert.strictEqual(body.success, false)
+        assert.ok(body.error)
+        assert.strictEqual(body.error.code, 'NotFound')
+    })
+})

--- a/backend/test/unit/getPromptTemplate.test.ts
+++ b/backend/test/unit/getPromptTemplate.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for GetPromptTemplate handler
  */
 
-import assert from 'node:assert'
-import { describe, test } from 'node:test'
 import type { HttpRequest, InvocationContext } from '@azure/functions'
 import type { IPromptTemplateRepository, PromptTemplate } from '@piquet-h/shared'
+import assert from 'node:assert'
+import { describe, test } from 'node:test'
 import { GetPromptTemplateHandler } from '../../src/handlers/getPromptTemplate.js'
 import { UnitTestFixture } from '../helpers/UnitTestFixture.js'
 
@@ -43,9 +43,10 @@ describe('GetPromptTemplateHandler', () => {
             const response = await handler.handle(mockReq, mockContext)
 
             assert.strictEqual(response.status, 400)
-            const body = JSON.parse(JSON.stringify(response.jsonBody))
-            assert.ok(body.err)
-            assert.strictEqual(body.err.code, 'MissingTemplateId')
+            const body = JSON.parse(JSON.stringify(response.jsonBody)) as { success: boolean; error?: { code: string } }
+            assert.strictEqual(body.success, false)
+            assert.ok(body.error)
+            assert.strictEqual(body.error.code, 'MissingTemplateId')
         })
 
         test('returns 404 if template not found', async () => {
@@ -69,9 +70,10 @@ describe('GetPromptTemplateHandler', () => {
             const response = await handler.handle(mockReq, mockContext)
 
             assert.strictEqual(response.status, 404)
-            const body = JSON.parse(JSON.stringify(response.jsonBody))
-            assert.ok(body.err)
-            assert.strictEqual(body.err.code, 'NotFound')
+            const body = JSON.parse(JSON.stringify(response.jsonBody)) as { success: boolean; error?: { code: string } }
+            assert.strictEqual(body.success, false)
+            assert.ok(body.error)
+            assert.strictEqual(body.error.code, 'NotFound')
 
             // Restore
             mockRepo.get = originalGet
@@ -94,9 +96,10 @@ describe('GetPromptTemplateHandler', () => {
             const response = await handler.handle(mockReq, mockContext)
 
             assert.strictEqual(response.status, 400)
-            const body = JSON.parse(JSON.stringify(response.jsonBody))
-            assert.ok(body.err)
-            assert.strictEqual(body.err.code, 'ConflictingParameters')
+            const body = JSON.parse(JSON.stringify(response.jsonBody)) as { success: boolean; error?: { code: string } }
+            assert.strictEqual(body.success, false)
+            assert.ok(body.error)
+            assert.strictEqual(body.error.code, 'ConflictingParameters')
         })
 
         test('returns 200 with template data when found', async () => {
@@ -126,10 +129,11 @@ describe('GetPromptTemplateHandler', () => {
             assert.strictEqual(response.headers['ETag'], 'abc123')
             assert.ok(response.headers['Cache-Control']?.includes('max-age=300'))
 
-            const body = JSON.parse(JSON.stringify(response.jsonBody))
-            assert.ok(body.ok)
-            assert.strictEqual(body.ok.id, 'location')
-            assert.strictEqual(body.ok.hash, 'abc123')
+            const body = JSON.parse(JSON.stringify(response.jsonBody)) as { success: boolean; data?: { id: string; hash: string } }
+            assert.strictEqual(body.success, true)
+            assert.ok(body.data)
+            assert.strictEqual(body.data.id, 'location')
+            assert.strictEqual(body.data.hash, 'abc123')
         })
 
         test('returns 304 Not Modified when ETag matches', async () => {


### PR DESCRIPTION
## Summary
- Require function-key auth for `GET /api/prompts/{id}` (Azure Functions `authLevel: 'function'`).
- Make prompt template caching configurable via `PROMPT_TEMPLATE_CACHE_TTL_SECONDS` (affects in-memory repo TTL and `Cache-Control: max-age`).
- Add integration tests for prompt template GET (200/304/400/404) and align unit tests to the standard HTTP envelope.
- Bump `@piquet-h/shared` to a version that exports `PromptTemplateRepository` at runtime.

## Notes
- Tests invoke the handler directly; the 401 behavior is enforced by Azure Functions runtime when deployed.

Closes #626